### PR TITLE
Avoiding empty blocks 

### DIFF
--- a/nodes/src/main/java/io/aexp/nodes/graphql/Property.java
+++ b/nodes/src/main/java/io/aexp/nodes/graphql/Property.java
@@ -60,7 +60,7 @@ final class Property {
             message.append(StringUtil.joinStringArray(",", argumentList));
             message.append(") ");
         }
-        if (children != null) {
+        if (children != null && !children.isEmpty()) {
             message.append("{ ");
             for (Map.Entry<String, Property> entry : children.entrySet()) {
                 message.append(entry.getValue().getMessage(entry.getKey()));


### PR DESCRIPTION
Hello!
It leads to syntax errors if there are empty blocks '{ }' in graphql requests. There will be an empty block in your request if you create a mutation with no response defined. In this case you have one property (mutation's name) with several arguments but no children. 
For example:
An empty class defining the mutation request:
` @GraphQLProperty(name="myMutation", arguments={
        @GraphQLArgument(name="myArgument1"), @GraphQLArgument(name="myArgument2")
    })
public class MyMutationModel {}`

Creating the request:
`GraphQLRequestEntity requestEntity = GraphQLRequestEntity.Builder()
    .url("http://graphql.example.com/graphql").
    .arguments(new Arguments("myMutation",
        new Argument("myArgument1", "value1"), new Argument("myArgument2", "value2")))
    .request(MyMutationModel.class)
    .build();
GraphQLResponseEntity<Boolean> responseEntity = graphQLTemplate.query(requestEntity, Boolean.class);`

The created request would look like this:
`mutation {myMutation(myArgument1:"value1", myArgument2:"value2") { } }`

But a vlid request has to look like this:

`mutation {myMutation(myArgument1:"value1", myArgument2:"value2") }`

I think it would be a good idea to prevent empty blocks from being created in general. Because Property.class' member variable "children" is an empty map, at least in this case, it is very likely that empty blocks will be created.

My little modification would fix this behaviour. Or is there another way to deal with requests like this?

Cheers,
Christian