### PR TITLE
feat(GraphQLArgument): introduce optional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ GraphQLResponseEntity<SampleModel> responseEntity = graphQLTemplate.query(reques
 
 ### Annotations to configure fields
 
-#### `@GraphQLArgument(name="name", value="defaultVal", type="String")`
-> Used above property fields<br><b>name (required)</b>: GraphQL argument name<br><b>value (optional)</b>: default value to set the argument to<br><b>type (optional)</b>: how to parse the optional value. Accepts an enum of "String", "Boolean", "Integer", or "Float" - defaults to be parsed as a string.<br>You can specify fields arguments directly inline using this. This is good for static field arguments such as result display settings, for instance the format of a date or the locale of a message.
+#### `@GraphQLArgument(name="name", value="defaultVal", type="String", optional=false)`
+> Used above property fields<br><b>name (required)</b>: GraphQL argument name<br><b>value (optional)</b>: default value to set the argument to<br><b>type (optional)</b>: how to parse the optional value. Accepts an enum of "String", "Boolean", "Integer", or "Float" - defaults to be parsed as a string.<br><b>optional (optional)</b>: set to true if the value is optional and should be left out if value is null - defaults to false.<br>You can specify fields arguments directly inline using this. This is good for static field arguments such as result display settings, for instance the format of a date or the locale of a message.
 
 *example:*
 ```java

--- a/nodes/src/main/java/io/aexp/nodes/graphql/GraphQLRequestEntity.java
+++ b/nodes/src/main/java/io/aexp/nodes/graphql/GraphQLRequestEntity.java
@@ -212,12 +212,14 @@ public final class GraphQLRequestEntity {
         String type = graphQLArgument.type();
         boolean optional = graphQLArgument.optional();
         String value = valueOf(graphQLArgument.value());
-        if ("Boolean".equalsIgnoreCase(type)) {
-            arguments.add(new Argument<Boolean>(graphQLArgument.name(), value == null ? null : Boolean.valueOf(value), optional));
+        if (value == null) {
+            arguments.add(new Argument<String>(graphQLArgument.name(), value, optional));
+        } else if ("Boolean".equalsIgnoreCase(type)) {
+            arguments.add(new Argument<Boolean>(graphQLArgument.name(), Boolean.valueOf(value), optional));
         } else if ("Integer".equalsIgnoreCase(type)) {
-            arguments.add(new Argument<Integer>(graphQLArgument.name(), value == null ? null : Integer.valueOf(value), optional));
+            arguments.add(new Argument<Integer>(graphQLArgument.name(), Integer.valueOf(value), optional));
         } else if ("Float".equalsIgnoreCase(type)) {
-            arguments.add(new Argument<Float>(graphQLArgument.name(), value == null ? null : Float.valueOf(value), optional));
+            arguments.add(new Argument<Float>(graphQLArgument.name(), Float.valueOf(value), optional));
         } else {
             arguments.add(new Argument<String>(graphQLArgument.name(), value, optional));
         }

--- a/nodes/src/main/java/io/aexp/nodes/graphql/GraphQLRequestEntity.java
+++ b/nodes/src/main/java/io/aexp/nodes/graphql/GraphQLRequestEntity.java
@@ -210,14 +210,16 @@ public final class GraphQLRequestEntity {
      */
     private List<Argument> setArgument(List<Argument> arguments, GraphQLArgument graphQLArgument) {
         String type = graphQLArgument.type();
+        boolean optional = graphQLArgument.optional();
+        String value = valueOf(graphQLArgument.value());
         if ("Boolean".equalsIgnoreCase(type)) {
-            arguments.add(new Argument<Boolean>(graphQLArgument.name(), Boolean.valueOf(graphQLArgument.value())));
+            arguments.add(new Argument<Boolean>(graphQLArgument.name(), value == null ? null : Boolean.valueOf(value), optional));
         } else if ("Integer".equalsIgnoreCase(type)) {
-            arguments.add(new Argument<Integer>(graphQLArgument.name(), Integer.valueOf(graphQLArgument.value())));
+            arguments.add(new Argument<Integer>(graphQLArgument.name(), value == null ? null : Integer.valueOf(value), optional));
         } else if ("Float".equalsIgnoreCase(type)) {
-            arguments.add(new Argument<Float>(graphQLArgument.name(), Float.valueOf(graphQLArgument.value())));
+            arguments.add(new Argument<Float>(graphQLArgument.name(), value == null ? null : Float.valueOf(value), optional));
         } else {
-            arguments.add(new Argument<String>(graphQLArgument.name(), graphQLArgument.value()));
+            arguments.add(new Argument<String>(graphQLArgument.name(), value, optional));
         }
         return arguments;
     }
@@ -309,6 +311,13 @@ public final class GraphQLRequestEntity {
             children.put(propertyKey, property);
         }
         return children;
+    }
+
+    private static String valueOf(String value) {
+        if (value == null || "null".equals(value)) {
+            return null;
+        }
+        return value;
     }
 
     public static class RequestBuilder {

--- a/nodes/src/main/java/io/aexp/nodes/graphql/Parameter.java
+++ b/nodes/src/main/java/io/aexp/nodes/graphql/Parameter.java
@@ -40,13 +40,18 @@ class Parameter<T> {
 
     @Override
     public String toString() {
-        return toString("Parameter");
+        return toString("Parameter", null);
     }
 
-    String toString(String name) {
-        return name + "{" +
-                "key='" + key + '\'' +
-                ", value=" + value +
-                '}';
+    String toString(String name, String extraFields) {
+        StringBuilder builder = new StringBuilder(name);
+        builder.append('{');
+        builder.append("key='").append(key).append('\'');
+        builder.append(", value=").append(value);
+        if (extraFields != null) {
+            builder.append(", ").append(extraFields);
+        }
+        builder.append('}');
+        return builder.toString();
     }
 }

--- a/nodes/src/main/java/io/aexp/nodes/graphql/Property.java
+++ b/nodes/src/main/java/io/aexp/nodes/graphql/Property.java
@@ -52,13 +52,17 @@ final class Property {
         }
         if (this.resourceName != null) message.append(": ").append(resourceName).append(" ");
         if (this.arguments != null && !this.arguments.isEmpty()) {
-            message.append("(");
             List<String> argumentList = new ArrayList<String>();
             for (Argument argument: arguments) {
-                argumentList.add(StringUtil.formatGraphQLParameter(argument.getKey(), argument.getValue()));
+                if (!argument.isOptional() || argument.getValue() != null) {
+                    argumentList.add(StringUtil.formatGraphQLParameter(argument.getKey(), argument.getValue()));
+                }
             }
-            message.append(StringUtil.joinStringArray(",", argumentList));
-            message.append(") ");
+            if (!argumentList.isEmpty()) {
+                message.append("(");
+                message.append(StringUtil.joinStringArray(",", argumentList));
+                message.append(") ");
+            }
         }
         if (children != null && !children.isEmpty()) {
             message.append("{ ");

--- a/nodes/src/main/java/io/aexp/nodes/graphql/StringUtil.java
+++ b/nodes/src/main/java/io/aexp/nodes/graphql/StringUtil.java
@@ -19,6 +19,9 @@ import java.util.regex.Pattern;
 
 abstract class StringUtil {
 
+    private StringUtil() {
+    }
+
     /**
      * Joins and array to a delimited string
      *
@@ -46,7 +49,7 @@ abstract class StringUtil {
         StringBuilder stringBuilder = new StringBuilder();
         Pattern pattern = Pattern.compile("^\\$");
         Matcher matcher = pattern.matcher("" + value);
-        if (value instanceof String && !"null".equalsIgnoreCase((String) value) && !matcher.find()) {
+        if (value instanceof String && !matcher.find()) {
             stringBuilder.append(key).append(":\"").append(value).append("\"");
         } else if (value instanceof List) {
             stringBuilder.append(key).append(":").append(formatGraphQLArgumentList((List) value));
@@ -71,7 +74,7 @@ abstract class StringUtil {
         for (Object value: values) {
             if (stringBuilder.length() != 1) stringBuilder.append(",");
             Matcher m = p.matcher("" + value);
-            if (value instanceof String && !"null".equalsIgnoreCase((String) value) && !m.find()) {
+            if (value instanceof String && !m.find()) {
                 stringBuilder.append("\"").append(value).append("\"");
             } else if (value instanceof InputObject) {
                 stringBuilder.append(((InputObject) value).getMessage());

--- a/nodes/src/main/java/io/aexp/nodes/graphql/Variable.java
+++ b/nodes/src/main/java/io/aexp/nodes/graphql/Variable.java
@@ -20,6 +20,6 @@ public class Variable<T> extends Parameter {
 
     @Override
     public String toString() {
-        return super.toString(this.getClass().getSimpleName());
+        return super.toString(this.getClass().getSimpleName(), null);
     }
 }

--- a/nodes/src/main/java/io/aexp/nodes/graphql/annotations/GraphQLArgument.java
+++ b/nodes/src/main/java/io/aexp/nodes/graphql/annotations/GraphQLArgument.java
@@ -26,4 +26,5 @@ public @interface GraphQLArgument {
     String name();
     String value() default "null";
     String type() default "null";
+    boolean optional() default false;
 }

--- a/nodes/src/test/java/io/aexp/nodes/graphql/ArgumentTest.java
+++ b/nodes/src/test/java/io/aexp/nodes/graphql/ArgumentTest.java
@@ -16,6 +16,7 @@ package io.aexp.nodes.graphql;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ArgumentTest {
 
@@ -30,7 +31,19 @@ public class ArgumentTest {
         argument.setValue("test");
         assertEquals("test", argument.getKey());
         assertEquals("test", argument.getValue());
-        assertEquals("Argument{key='test', value=test}", argument.toString());
+        assertEquals("Argument{key='test', value=test, optional=false}", argument.toString());
+    }
+
+    @Test
+    public void argumentOptionalTest() {
+        Argument argument = new Argument(null, null, false);
+        argument.setKey("k");
+        argument.setValue("v");
+        argument.setOptional(true);
+        assertEquals("k", argument.getKey());
+        assertEquals("v", argument.getValue());
+        assertTrue(argument.isOptional());
+        assertEquals("Argument{key='k', value=v, optional=true}", argument.toString());
     }
 
     @Test
@@ -40,7 +53,7 @@ public class ArgumentTest {
         argument.setValue(1);
         assertEquals("test", argument.getKey());
         assertEquals(1, argument.getValue());
-        assertEquals("Argument{key='test', value=1}", argument.toString());
+        assertEquals("Argument{key='test', value=1, optional=false}", argument.toString());
     }
 
     @Test
@@ -50,8 +63,9 @@ public class ArgumentTest {
         argument.setValue(STATUS.active);
         assertEquals("test", argument.getKey());
         assertEquals(STATUS.active, argument.getValue());
-        assertEquals("Argument{key='test', value=active}", argument.toString());
+        assertEquals("Argument{key='test', value=active, optional=false}", argument.toString());
     }
+
     @Test
     public void argumentInputObjectTest() {
         Argument argument = new Argument(null, null);

--- a/nodes/src/test/java/io/aexp/nodes/graphql/ArgumentsTest.java
+++ b/nodes/src/test/java/io/aexp/nodes/graphql/ArgumentsTest.java
@@ -23,6 +23,6 @@ public class ArgumentsTest {
     public void argumentsTest() {
         Arguments arguments = new Arguments("somePath", new Argument<String>("someKey", "someValue"));
         assertEquals("somePath", arguments.getDotPath());
-        assertEquals("Arguments{dotPath='somePath', arguments=[Argument{key='someKey', value=someValue}]}", arguments.toString());
+        assertEquals("Arguments{dotPath='somePath', arguments=[Argument{key='someKey', value=someValue, optional=false}]}", arguments.toString());
     }
 }

--- a/nodes/src/test/java/io/aexp/nodes/graphql/GraphQLRequestEntityTest.java
+++ b/nodes/src/test/java/io/aexp/nodes/graphql/GraphQLRequestEntityTest.java
@@ -13,6 +13,7 @@
 
 package io.aexp.nodes.graphql;
 
+import org.junit.Before;
 import org.junit.Test;
 import io.aexp.nodes.graphql.models.TestModel;
 import io.aexp.nodes.graphql.models.TestModelEnum;
@@ -21,7 +22,9 @@ import io.aexp.nodes.graphql.models.TestModelScalar;
 
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -32,7 +35,15 @@ public class GraphQLRequestEntityTest {
         active
     }
 
-    private String EXAMPLE_URL = "https://graphql.example.com";
+    private static String EXAMPLE_URL = "https://graphql.example.com";
+    private List<String> idList;
+
+    @Before
+    public void setUp() {
+        idList = new ArrayList<String>();
+        idList.add("47");
+        idList.add("$id");
+    }
 
     @Test
     public void requestWithoutUrl() {
@@ -63,11 +74,14 @@ public class GraphQLRequestEntityTest {
         GraphQLRequestEntity requestEntity = GraphQLRequestEntity.Builder()
                 .url(EXAMPLE_URL)
                 .request(TestModelOptionalArguments.class)
-                .arguments(new Arguments("test.nested", new Argument<Integer>("first", 10)))
+                .arguments(
+                        new Arguments("test.nested",
+                                new Argument<List<String>>("ids", idList),
+                                new Argument<Integer>("first", 10)))
                 .build();
         requestEntity.setRequestMethod(GraphQLTemplate.GraphQLMethod.QUERY);
         assertEquals(EXAMPLE_URL, requestEntity.getUrl().toString());
-        assertEquals("GraphQLRequestEntity{request='query { test { nested (first:10) { string } } } ', url='"+EXAMPLE_URL+"'}", requestEntity.toString());
+        assertEquals("GraphQLRequestEntity{request='query { test { nested (ids:[\"47\",$id],first:10) { string } } } ', url='"+EXAMPLE_URL+"'}", requestEntity.toString());
     }
 
     @Test
@@ -75,11 +89,14 @@ public class GraphQLRequestEntityTest {
         GraphQLRequestEntity requestEntity = GraphQLRequestEntity.Builder()
                 .url(EXAMPLE_URL)
                 .request(TestModelOptionalArguments.class)
-                .arguments(new Arguments("test.nested", new Argument<Integer>("last", 5)))
+                .arguments(
+                        new Arguments("test.nested",
+                                new Argument<List<String>>("ids", idList),
+                                new Argument<Integer>("last", 5)))
                 .build();
         requestEntity.setRequestMethod(GraphQLTemplate.GraphQLMethod.QUERY);
         assertEquals(EXAMPLE_URL, requestEntity.getUrl().toString());
-        assertEquals("GraphQLRequestEntity{request='query { test { nested (last:5) { string } } } ', url='"+EXAMPLE_URL+"'}", requestEntity.toString());
+        assertEquals("GraphQLRequestEntity{request='query { test { nested (ids:[\"47\",$id],last:5) { string } } } ', url='"+EXAMPLE_URL+"'}", requestEntity.toString());
     }
 
     @Test

--- a/nodes/src/test/java/io/aexp/nodes/graphql/GraphQLRequestEntityTest.java
+++ b/nodes/src/test/java/io/aexp/nodes/graphql/GraphQLRequestEntityTest.java
@@ -16,6 +16,7 @@ package io.aexp.nodes.graphql;
 import org.junit.Test;
 import io.aexp.nodes.graphql.models.TestModel;
 import io.aexp.nodes.graphql.models.TestModelEnum;
+import io.aexp.nodes.graphql.models.TestModelOptionalArguments;
 import io.aexp.nodes.graphql.models.TestModelScalar;
 
 import java.math.BigDecimal;
@@ -55,6 +56,30 @@ public class GraphQLRequestEntityTest {
         }
         assertNotNull(exception);
         assertEquals("request must be set", exception.getMessage());
+    }
+
+    @Test
+    public void requestWithOptionalParameter() throws MalformedURLException {
+        GraphQLRequestEntity requestEntity = GraphQLRequestEntity.Builder()
+                .url(EXAMPLE_URL)
+                .request(TestModelOptionalArguments.class)
+                .arguments(new Arguments("test.nested", new Argument<Integer>("first", 10)))
+                .build();
+        requestEntity.setRequestMethod(GraphQLTemplate.GraphQLMethod.QUERY);
+        assertEquals(EXAMPLE_URL, requestEntity.getUrl().toString());
+        assertEquals("GraphQLRequestEntity{request='query { test { nested (first:10) { string } } } ', url='"+EXAMPLE_URL+"'}", requestEntity.toString());
+    }
+
+    @Test
+    public void requestWithOtherOptionalParameter() throws MalformedURLException {
+        GraphQLRequestEntity requestEntity = GraphQLRequestEntity.Builder()
+                .url(EXAMPLE_URL)
+                .request(TestModelOptionalArguments.class)
+                .arguments(new Arguments("test.nested", new Argument<Integer>("last", 5)))
+                .build();
+        requestEntity.setRequestMethod(GraphQLTemplate.GraphQLMethod.QUERY);
+        assertEquals(EXAMPLE_URL, requestEntity.getUrl().toString());
+        assertEquals("GraphQLRequestEntity{request='query { test { nested (last:5) { string } } } ', url='"+EXAMPLE_URL+"'}", requestEntity.toString());
     }
 
     @Test

--- a/nodes/src/test/java/io/aexp/nodes/graphql/ParameterTest.java
+++ b/nodes/src/test/java/io/aexp/nodes/graphql/ParameterTest.java
@@ -38,4 +38,9 @@ public class ParameterTest {
         assertEquals(value, parameter.getValue());
     }
 
+    @Test
+    public void parameterStringTest() {
+        Parameter<String> parameter = new Parameter<String>("key", "value");
+        assertEquals("Parameter{key='key', value=value}", parameter.toString());
+    }
 }

--- a/nodes/src/test/java/io/aexp/nodes/graphql/models/NestedTestModelOptionalArguments.java
+++ b/nodes/src/test/java/io/aexp/nodes/graphql/models/NestedTestModelOptionalArguments.java
@@ -11,31 +11,24 @@
  * the License.
  */
 
-package io.aexp.nodes.graphql;
+package io.aexp.nodes.graphql.models;
 
-public class Argument<T> extends Parameter<T> {
-    private boolean optional;
+public class NestedTestModelOptionalArguments {
 
-    public Argument(String key, T value) {
-        this(key, value, false);
+    private String string;
+
+    public String getString() {
+        return string;
     }
 
-    public Argument(String key, T value, boolean optional) {
-        super(key, value);
-        this.optional = optional;
-    }
-
-    public boolean isOptional() {
-        return optional;
-    }
-
-    public void setOptional(boolean optional) {
-        this.optional = optional;
+    public void setString(String anotherTestString) {
+        this.string = anotherTestString;
     }
 
     @Override
     public String toString() {
-        return super.toString(this.getClass().getSimpleName(),
-                "optional=" + optional);
+        return "NestedTestModelOptionalArguments{" +
+                "string='" + string + '\'' +
+                '}';
     }
 }

--- a/nodes/src/test/java/io/aexp/nodes/graphql/models/TestModelOptionalArguments.java
+++ b/nodes/src/test/java/io/aexp/nodes/graphql/models/TestModelOptionalArguments.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.aexp.nodes.graphql.models;
+
+import io.aexp.nodes.graphql.annotations.GraphQLArgument;
+import io.aexp.nodes.graphql.annotations.GraphQLArguments;
+import io.aexp.nodes.graphql.annotations.GraphQLProperty;
+
+@GraphQLProperty(name = "test")
+public class TestModelOptionalArguments {
+    @GraphQLArguments({
+        @GraphQLArgument(name = "first", type = "Integer", optional = true),
+        @GraphQLArgument(name = "last", type = "Integer", optional = true)
+    })
+    private NestedTestModelOptionalArguments nested;
+
+    public NestedTestModelOptionalArguments getNested() {
+        return nested;
+    }
+
+    public void setNestedTestModelOptionalArguments(NestedTestModelOptionalArguments nested) {
+        this.nested = nested;
+    }
+
+    @Override
+    public String toString() {
+        return "TestModelOptionalArguments{" + "nested=" + nested + '}';
+    }
+}

--- a/nodes/src/test/java/io/aexp/nodes/graphql/models/TestModelOptionalArguments.java
+++ b/nodes/src/test/java/io/aexp/nodes/graphql/models/TestModelOptionalArguments.java
@@ -20,6 +20,7 @@ import io.aexp.nodes.graphql.annotations.GraphQLProperty;
 @GraphQLProperty(name = "test")
 public class TestModelOptionalArguments {
     @GraphQLArguments({
+        @GraphQLArgument(name = "ids"),
         @GraphQLArgument(name = "first", type = "Integer", optional = true),
         @GraphQLArgument(name = "last", type = "Integer", optional = true)
     })

--- a/nodes/src/test/java/io/aexp/nodes/graphql/scenarios/ArgumentSettingTest.java
+++ b/nodes/src/test/java/io/aexp/nodes/graphql/scenarios/ArgumentSettingTest.java
@@ -81,8 +81,8 @@ public class ArgumentSettingTest {
             exception = e;
         }
         assertNotNull(exception);
-        assertEquals("Argument 'Argument{key='test', value=1}' doesn't exist on path 'test'", exception.getMessage());
+        assertEquals("Argument 'Argument{key='test', value=1, optional=false}' doesn't exist on path 'test'", exception.getMessage());
         assertNull(exception.getErrors());
-        assertEquals("GraphQLException{message='Argument 'Argument{key='test', value=1}' doesn't exist on path 'test'', status='null', description='null', errors=null}", exception.toString());
+        assertEquals("GraphQLException{message='Argument 'Argument{key='test', value=1, optional=false}' doesn't exist on path 'test'', status='null', description='null', errors=null}", exception.toString());
     }
 }


### PR DESCRIPTION
Extend GraphQLArgument annotation class with field "optional" (default to false for backward compatibility)

Proposal for handling of API with mutually exclusive arguments using annotations. See test cases in GraphQLRequestEntityTest.

Closes #56