### PR TITLE
feat (connection/config): added connect timeout and read timeout.

### DIFF
--- a/nodes/src/main/java/io/aexp/nodes/graphql/Fetch.java
+++ b/nodes/src/main/java/io/aexp/nodes/graphql/Fetch.java
@@ -36,9 +36,18 @@ final class Fetch {
     private ObjectMapper mapper;
     private SimpleModule module;
     private static final int STATUS_CODE_THRESHOLD = 400;
+    private int connectTimeout = -1;
+    private int readTimeout = -1;
 
     Fetch(ObjectMapperFactory objectMapperFactory) {
         this.objectMapperFactory = objectMapperFactory;
+    }
+
+    Fetch(ObjectMapperFactory objectMapperFactory, int connectTimeout, int readTimeout) {
+        this(objectMapperFactory);
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
+
     }
 
     <T> GraphQLResponseEntity<T> send(GraphQLRequestEntity requestEntity, Class<T> responseClass) throws GraphQLException {
@@ -116,6 +125,13 @@ final class Fetch {
             connection.setRequestProperty(entry.getKey(), entry.getValue());
         }
         connection.setUseCaches(false);
+        if (this.connectTimeout >= 0) {
+            connection.setConnectTimeout(this.connectTimeout);
+        }
+
+        if (this.readTimeout >= 0) {
+            connection.setReadTimeout(this.readTimeout);
+        }
         return connection;
     }
 

--- a/nodes/src/main/java/io/aexp/nodes/graphql/GraphQLTemplate.java
+++ b/nodes/src/main/java/io/aexp/nodes/graphql/GraphQLTemplate.java
@@ -49,6 +49,29 @@ public class GraphQLTemplate {
     }
 
     /**
+     * Constructs a new GraphQL template instance using the default ObjectMapper factory,
+     * connect and read timeout for the underlying HttpURLConnection.
+     * @param connectTimeout Sets a specified timeout value, in milliseconds, to be used
+     *     when opening a communications link
+     * @param readTimeout Sets the read timeout to a specified timeout, in milliseconds
+     */
+    public GraphQLTemplate(int connectTimeout, int readTimeout) {
+        this(new DefaultObjectMapperFactory(), connectTimeout, readTimeout);
+    }
+
+    /**
+     * Constructs a new GraphQL template instance using the specified ObjectMapper factory,
+     * connect and read timeout for the underlying HttpURLConnection.
+     * @param objectMapperFactory factory class used for creating ObjectMapper instances
+     * @param connectTimeout Sets a specified timeout value, in milliseconds, to be used
+     *      when opening a communications link
+     * @param readTimeout Sets the read timeout to a specified timeout, in milliseconds
+     */
+    public GraphQLTemplate(final ObjectMapperFactory objectMapperFactory, int connectTimeout, int readTimeout) {
+        fetch = new Fetch(objectMapperFactory, connectTimeout, readTimeout);
+    }
+
+    /**
      * Execute a GraphQL query request.
      * @param requestEntity request entity to be executed upon
      * @param responseClass response from the execution

--- a/nodes/src/test/java/io/aexp/nodes/graphql/GraphQLTemplateTest.java
+++ b/nodes/src/test/java/io/aexp/nodes/graphql/GraphQLTemplateTest.java
@@ -20,6 +20,7 @@ import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -232,5 +233,26 @@ public class GraphQLTemplateTest {
         }
         assertNotNull(exception);
         assertEquals(exception.getMessage(), "requestEntity must not be null");
+    }
+
+    @Test
+    public void timeOutVariables() throws MalformedURLException {
+        graphQLTemplate = new GraphQLTemplate(2000, 2000);
+        server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE));
+        HttpUrl serviceUrl = server.url("/serverTimeout");
+        GraphQLRequestEntity requestEntity = GraphQLRequestEntity.Builder()
+                .url(serviceUrl.toString())
+                .request(TestModel.class)
+                .build();
+        GraphQLException exception = null;
+        try {
+            graphQLTemplate.query(requestEntity, TestModel.class);
+        } catch (GraphQLException e) {
+            exception = e;
+        }
+        assertNotNull(exception);
+        assertEquals(exception.getDescription(), "Read timed out");
+
+
     }
 }


### PR DESCRIPTION
feat (connection/config): added connect timeout and read timeout.
GraphQLTemplate now allows to configure the timeouts for underlying HttpURLConnection.