### PR TITLE
chore(build): add source to maven repository

### DIFF
--- a/nodes/pom.xml
+++ b/nodes/pom.xml
@@ -131,6 +131,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Attach the source of the nodes jar, so that it gets included
in the maven repository. This allows IDEs to autodownload the
source for better debugging and code completion support.