### PR TITLE
chore(travis): Use trusty for oraclejdk8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: java
 
 cache:


### PR DESCRIPTION
Oracle JDK 8 is preinstalled in trusty, but isn't in xenial anymore.
So for the time beeing fix the distribution to trusty.